### PR TITLE
Correção de width e height no componente Faq

### DIFF
--- a/src/app/components/Faq/index.tsx
+++ b/src/app/components/Faq/index.tsx
@@ -68,7 +68,7 @@ const Faq = () => {
                                 width: "25rem"
                             }}
                         >
-                            {item.pergunta} <Image src="Icon+.svg" alt="icor" width={100} height={100} />
+                            {item.pergunta} <Image src="Icon+.svg" alt="icone" width={10} height={10} />
                         </div>
                         {activeIndex === index && (
                             <div style={{ 


### PR DESCRIPTION
### Descrição
Correção de width e height da tag Image do componente Faq + correção de sua propriedade "alt"

### Impacto
- Correção de tamanho da imagem
- Ajustes na interface
- Interface otimizada e respondendo a um bom padrão de tamanho de altura e largura do componente

### Como testar
1. Segue prints de antes e depois.
![CorreçãoFaq](https://github.com/user-attachments/assets/8e1671f4-26d8-4441-9e48-3bad95d45b2b)
![CorreçãoFaq2](https://github.com/user-attachments/assets/3849d48b-1770-4cbe-945f-f45dbeabe885)
